### PR TITLE
Use preinstalled curl instead of winget-installed wget in Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,15 +69,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
-      - name: Install wget (Windows only)
-        if: runner.os == 'Windows'
-        run: winget install --id JernejSimoncic.Wget --silent --accept-package-agreements --accept-source-agreements
-      - name: Add wget to PATH
-        if: runner.os == 'Windows'
-        run: echo "$env:LOCALAPPDATA\Microsoft\WinGet\Links" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: powershell
       - name: Workaround pypa/pipx#1539
-        run: wget https://raw.githubusercontent.com/jaraco/pipx-1539/main/workaround-1539.py -O - | python3
+        run: curl -fsSL https://raw.githubusercontent.com/jaraco/pipx-1539/main/workaround-1539.py | python3
       - name: Run tests for ${{ matrix.python }} (${{ runner.os }})
         run: pipx run --python ${{ matrix.python }} 'coherent.test>=0.7.0'
         env:


### PR DESCRIPTION
## Problem

Windows CI builds fail at the **Install wget** step because `winget`'s source index is intermittently broken on GitHub-hosted Windows runners:

```
Failed in attempting to update the source: winget
0x8a15000f : Data required by the source is missing
No packages were found among the working sources.
```

## Fix

`wget` was only installed so the `pypa/pipx#1539` workaround step could pipe a script to `python3`. `curl` is preinstalled on **all** GitHub-hosted runners (Ubuntu, macOS, Windows) and the job already runs under bash, so this drops the two flaky Windows-only steps entirely and uses `curl -fsSL` instead.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)