### PR TITLE
Add licensing guidance to the getting-started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To indicate a license, declare a [SPDX license expression](https://spdx.org/lice
 __license__ = "Apache-2.0"
 ```
 
-The system then publishes that expression in the package metadata and renders the corresponding license text in the distribution.
+The system then publishes that expression in the package metadata and renders the corresponding license text in the distribution. Omitting a license indicator will leave the distribution without any indicated license.
 
 Add a README.md to the repo to give users an overview to be included in the project's description.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ __requires__ = [
 > To extract the `__requires__` list to pass it to pip or other tools,
 > check [_Extracting Requirements_ in pip-run](https://github.com/jaraco/pip-run#extracting-requirements).
 
+Want to declare a license? License selection is treated as a positive signal, so a project without a declared license simply carries no license metadata. To indicate one, declare a [SPDX license expression](https://spdx.org/licenses/) in the `__license__` attribute of `__init__.py`:
+
+```python
+__license__ = "Apache-2.0"
+```
+
+The system then publishes that expression in the package metadata and, for supported layouts, includes the corresponding license text in the distribution.
+
 Add a README.md to the repo to give users an overview to be included in the project's description.
 
 Ready to create some tests? Create doctests or a `tests` dir with modules containing pytest tests. Then run the tests using `coh test` or `pipx run coherent.cli test`:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Want to declare a license? License selection is treated as a positive signal, so
 __license__ = "Apache-2.0"
 ```
 
-The system then publishes that expression in the package metadata and, for supported layouts, includes the corresponding license text in the distribution.
+The system then publishes that expression in the package metadata and renders the corresponding license text in the distribution.
 
 Add a README.md to the repo to give users an overview to be included in the project's description.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ __requires__ = [
 > To extract the `__requires__` list to pass it to pip or other tools,
 > check [_Extracting Requirements_ in pip-run](https://github.com/jaraco/pip-run#extracting-requirements).
 
-Want to declare a license? License selection is treated as a positive signal, so a project without a declared license simply carries no license metadata. To indicate one, declare a [SPDX license expression](https://spdx.org/licenses/) in the `__license__` attribute of `__init__.py`:
+To indicate a license, declare a [SPDX license expression](https://spdx.org/licenses/) in the `__license__` attribute of `__init__.py`:
 
 ```python
 __license__ = "Apache-2.0"


### PR DESCRIPTION
Documents how to declare a license via the `__license__` attribute in `__init__.py`, per coherent-oss/coherent.build#67.

License selection is treated as a positive signal with no default — a project without a declared license carries no license metadata. This adds a short "Want to declare a license?" section to the getting-started guide showing the SPDX expression form (`__license__ = "Apache-2.0"`).

Ref coherent-oss/coherent.build#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)